### PR TITLE
doc: Fix NEWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ changes should be backwards compatible with your existing workflows.
 _all_ use cases. This is changed from 6 hours in `v2`. You can adjust this value
 with the `role-duration-seconds` input.
 - By default, your account ID will not be masked in workflow logs. This was
-changed from being masked by default in the previous version. AWS does consider
+changed from being masked by default in the previous version. AWS does not consider
 account IDs as sensitive information, so this change reflects that stance. You
 can revert to the old default and mask your account ID in workflow logs by
 setting the `mask-aws-account-id` input to `true`.


### PR DESCRIPTION
*Description of changes:*

https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html

>While account IDs, like any identifying information, should be used and shared carefully, they are not considered secret, sensitive, or confidential information.

Given the above, I fix README as "AWS does **not** consider account IDs as sensitive information" is correct.

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
